### PR TITLE
issue #1 - dynamic footer menu

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -17,58 +17,12 @@
 		<div class="container">
 <!--			<div class="title has-text-light has-text-centered">Stay in Touch!</div>-->
 			<div class="site-footer__social-items">
-				<a
-					href="https://twitter.com/atldemsoc"
-					target="_blank"
-					rel="noopener"
-					class="site-footer__social-item"
-				>
-					<div class="site-footer__social-item__icon">
-						<span class="icon is-medium">
-							<i class="fab fa-twitter fa-2x"></i>
-						</span>
-					</div>
-					<div class="site-footer__social-item__label">ATL DSA Twitter</div>
-				</a>
-				<a
-					href="https://www.instagram.com/atldemsoc/"
-					target="_blank"
-					rel="noopener"
-					class="site-footer__social-item"
-				>
-					<div class="site-footer__social-item__icon">
-						<span class="icon is-medium">
-							<i class="fab fa-instagram fa-2x"></i>
-						</span>
-					</div>
-					<div class="site-footer__social-item__label">ATL DSA Instagram</div>
-				</a>
-				<a
-					href="https://www.facebook.com/atldemsoc/"
-					target="_blank"
-					rel="noopener"
-					class="site-footer__social-item"
-				>
-					<div class="site-footer__social-item__icon">
-						<span class="icon is-medium">
-							<i class="fab fa-facebook fa-2x"></i>
-						</span>
-					</div>
-					<div class="site-footer__social-item__label">ATL DSA Facebook</div>
-				</a>
-				<a
-					href="http://www.dsausa.org/"
-					target="_blank"
-					rel="noopener"
-					class="site-footer__social-item"
-				>
-					<div class="site-footer__social-item__icon">
-						<span class="icon is-medium">
-							<i class="fas fa-fist-raised fa-2x"></i>
-						</span>
-					</div>
-					<div class="site-footer__social-item__label">National DSA</div>
-				</a>
+                <?php wp_nav_menu(array(
+                    'theme_location' => 'footer-menu',
+                    'container' => false,
+                    'items_wrap' => '%3$s',
+                    'walker' => new footer_menu_walker()
+                )); ?>
 			</div>
 			<div class="site-footer__copyright">&copy; <?= date('Y'); ?> Atlanta DSA</div>
 		</div>

--- a/functions.php
+++ b/functions.php
@@ -44,7 +44,8 @@ if ( ! function_exists( '_s_setup' ) ) :
 
 		// This theme uses wp_nav_menu() in one location.
 		register_nav_menus( array(
-			'menu-1' => esc_html__( 'Primary', '_s' ),
+			'primary-menu' => esc_html__( 'Primary Menu'),
+            'footer-menu' => esc_html__('Footer Menu'),
 		) );
 
 		/*
@@ -174,4 +175,23 @@ require get_template_directory() . '/inc/custom-fields.php';
 function get_template_partial($name, $parameters = []) {
 	extract($parameters);
 	require get_template_directory() . '/partials/' . $name . '.php';
+}
+
+class footer_menu_walker extends Walker_Nav_Menu
+{
+    function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0)
+    {
+        $class_names = join(' ', $item->classes);
+        $menu_item =
+            '<a href="' . esc_attr($item->url) . '" target="_blank" rel="noopener" class="site-footer__social-item">' .
+                '<div class="site-footer__social-item__icon">' .
+                    '<span class="icon is-medium">' .
+                        '<i class="fa-2x ' . $class_names . '"></i>' .
+                    '</span>' .
+                '</div>' .
+                '<div class="site-footer__social-item__label">' . esc_attr($item->attr_title) . '</div>' .
+            '</a>';
+
+        $output .= apply_filters('walker_nav_menu_start_el', $menu_item, $item, $depth, $args);
+    }
 }

--- a/header.php
+++ b/header.php
@@ -55,7 +55,7 @@ $chapterName = $chapterName ? $chapterName : 'Metro Atlanta';
 					 class="navbar-menu">
 				<div class="navbar-end">
 					<?php wp_nav_menu(array(
-						'theme-location' => 'header-menu', //change it according to your register_nav_menus() function
+						'theme_location' => 'primary-menu', //change it according to your register_nav_menus() function
 						'depth' => 2,
 						'menu' => 'NewNav',
 						'container' => '',


### PR DESCRIPTION
Includes bugfix for incorrect theme location key in menu initialization.  The theme was using the key 'theme-location' which was a typo.  The correct key is 'theme_location'.  This was causing shit to go bananas when there were multiple menus, since they weren't actually assigned a location.
https://developer.wordpress.org/reference/functions/wp_nav_menu/